### PR TITLE
Add item thumbnail attribute for spinning animation

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -241,3 +241,12 @@ div.post {
     width: 100%;
     padding: 10px;
 }
+
+@keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(359deg);
+    }
+}


### PR DESCRIPTION
Just something fun since I didn't feel like working on thread replies yet lol

![spinning-attribute](https://user-images.githubusercontent.com/18600213/147848379-d2a960c5-c4f8-4157-8f95-0f3547bb75d0.gif)
^The spinning is much smoother than is depicted in the low framerate gif.  

This, imo, is a really easy and fun way to add depth to reactions.  Basically gate [all these css filters](https://www.w3schools.com/cssref/css3_pr_filter.asp) behind a `chance_to_occur`.  Then, like...a spinning, high contrast, blurry pogface is super collectable.  

The idea is to place these modifiers in the item overlay down by the item rarity.  The more modifier attributes you got on your item, the cooler it is basically.  